### PR TITLE
Remove `preview`; unify into `execute` and `run`

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -165,8 +165,7 @@ package-level requirements and skip project-sync backends:
 
 ```python
 params = SetupParameters(paths=manifest_path, project_directory=False)
-preview = api.sync.preview_batch(params)
-results = execute_stream(preview, params)
+results = api.sync.run(params)
 
 # Inspect which actions were skipped and why
 for skip in results.skips:
@@ -189,20 +188,20 @@ from porringer.schema import LocalConfiguration, SetupParameters
 api = API(LocalConfiguration())
 
 # Full sync (project + packages)
-preview = api.sync.preview_batch(SetupParameters(paths=project_path))
+results = api.sync.run(SetupParameters(paths=project_path))
 
 # Packages only — skip project backends and post-sync commands
-preview = api.sync.preview_batch(SetupParameters(paths=manifest_path, project_directory=False))
+results = api.sync.run(SetupParameters(paths=manifest_path, project_directory=False))
 
 # Override project directory (manifest and project in different locations)
-preview = api.sync.preview_batch(
+results = api.sync.run(
     SetupParameters(paths=manifest_path, project_directory=project_path)
 )
 
 # Execute with streaming progress
 async def run():
-    async for event in api.sync.execute_stream(preview, SetupParameters(paths=project_path)):
-        print(event.kind, event.action.description)
+    async for event in api.sync.execute_stream(SetupParameters(paths=project_path)):
+        print(event.kind, getattr(event.action, 'description', 'manifest loaded'))
 
 asyncio.run(run())
 ```

--- a/porringer/backend/command/sync.py
+++ b/porringer/backend/command/sync.py
@@ -569,8 +569,12 @@ class SyncCommands:
         return actions
 
     @staticmethod
-    def preview_single(path: Path, strategy: SyncStrategy = SyncStrategy.MINIMAL) -> SetupResults:
-        """Previews the setup actions for a single path without executing them.
+    def parse_manifest(path: Path, strategy: SyncStrategy = SyncStrategy.MINIMAL) -> SetupResults:
+        """Parse a manifest and build the action plan without executing.
+
+        This is a low-level utility for manifest inspection (e.g. validating
+        that a manifest produces the expected actions).  For execution and
+        dry-run, use :meth:`execute_stream` or :meth:`run` instead.
 
         Args:
             path: Path to manifest file or directory containing one.
@@ -582,7 +586,7 @@ class SyncCommands:
         Raises:
             ManifestError: If the manifest cannot be found or parsed.
         """
-        logger.info(f'Previewing setup from: {path}')
+        logger.info(f'Parsing manifest from: {path}')
 
         manifest_path, manifest = SyncCommands._find_manifest(path)
         environments = SyncCommands._discover_plugins('environment', Environment, check_dependencies=True)
@@ -597,32 +601,6 @@ class SyncCommands:
         )
 
         return SetupResults(actions=actions, manifest_path=manifest_path, metadata=metadata)
-
-    def preview_batch(self, parameters: SetupParameters) -> BatchSetupResults:
-        """Preview setup actions for multiple paths.
-
-        Args:
-            parameters: The setup parameters with paths or group.
-
-        Returns:
-            BatchSetupResults containing previews for each manifest.
-        """
-        paths = self._resolve_paths(parameters)
-        logger.info(f'Previewing setup for {len(paths)} path(s)')
-
-        manifest_results: list[SetupResults] = []
-        failed_paths: list[tuple[Path, str]] = []
-
-        for path in paths:
-            try:
-                result = self.preview_single(path, strategy=parameters.strategy)
-                manifest_results.append(result)
-            except ManifestError as e:
-                failed_paths.append((path, str(e.error)))
-                if parameters.fail_fast:
-                    break
-
-        return BatchSetupResults(manifest_results=manifest_results, failed_paths=failed_paths)
 
     @staticmethod
     def _dry_run_action(
@@ -1646,28 +1624,57 @@ class SyncCommands:
 
     async def execute_stream(
         self,
-        previews: BatchSetupResults,
         parameters: SetupParameters,
     ) -> AsyncIterator[ProgressEvent]:
-        """Stream progress events while executing setup actions for multiple manifests.
+        """Stream progress events while executing setup actions.
 
-        Yields ``ProgressEvent`` items as actions start, complete, and report
-        sub-action detail.  Cancellation is handled via standard
-        ``task.cancel()`` on the consuming task.
+        Resolves paths, parses manifests, and executes (or dry-runs) in a
+        single call.  A :attr:`ProgressEventKind.MANIFEST_LOADED` event is
+        emitted for each successfully parsed manifest before its actions
+        begin executing.
+
+        Yields ``ProgressEvent`` items as manifests are loaded, actions
+        start, complete, and report sub-action detail.  Cancellation is
+        handled via standard ``task.cancel()`` on the consuming task.
 
         Args:
-            previews: The batch preview results containing actions per manifest.
-            parameters: The setup parameters.
+            parameters: The setup parameters (paths, dry_run, strategy, etc.).
 
         Yields:
-            ProgressEvent for each action lifecycle transition and sub-action update.
+            ProgressEvent for each manifest load, action lifecycle transition,
+            and sub-action update.
         """
         queue: asyncio.Queue[ProgressEvent | None] = asyncio.Queue()
 
         async def _run() -> None:
-            """Execute all manifests, emitting events into *queue*."""
+            """Resolve paths, parse manifests, execute, and emit events."""
             try:
-                for preview in previews.manifest_results:
+                paths = self._resolve_paths(parameters)
+                logger.info(f'Executing setup for {len(paths)} path(s) (dry_run={parameters.dry_run})')
+
+                for path in paths:
+                    try:
+                        preview = self.parse_manifest(path, strategy=parameters.strategy)
+                    except ManifestError as e:
+                        logger.warning(f'Failed to load manifest at {path}: {e.error}')
+                        queue.put_nowait(
+                            ProgressEvent(
+                                kind=ProgressEventKind.MANIFEST_FAILED,
+                                failed_path=(path, str(e.error)),
+                            )
+                        )
+                        if parameters.fail_fast:
+                            break
+                        continue
+
+                    # Emit MANIFEST_LOADED so consumers know the action plan
+                    queue.put_nowait(
+                        ProgressEvent(
+                            kind=ProgressEventKind.MANIFEST_LOADED,
+                            manifest=preview,
+                        )
+                    )
+
                     if preview.manifest_path is None:
                         continue
 
@@ -1693,3 +1700,50 @@ class SyncCommands:
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
+
+    def run(self, parameters: SetupParameters) -> BatchSetupResults:
+        """Execute setup synchronously and return collected results.
+
+        Resolves paths and parses manifests synchronously, then executes
+        (or dry-runs) actions via :meth:`execute_stream` for each manifest.
+
+        Args:
+            parameters: The setup parameters (paths, dry_run, strategy, etc.).
+
+        Returns:
+            BatchSetupResults from execution.
+        """
+        paths = self._resolve_paths(parameters)
+        logger.info(f'Running setup for {len(paths)} path(s) (dry_run={parameters.dry_run})')
+
+        manifest_results: list[SetupResults] = []
+        failed_paths: list[tuple[Path, str]] = []
+        previews: list[SetupResults] = []
+
+        # Phase 1: synchronous manifest loading
+        for path in paths:
+            try:
+                preview = self.parse_manifest(path, strategy=parameters.strategy)
+                previews.append(preview)
+            except ManifestError as e:
+                failed_paths.append((path, str(e.error)))
+                if parameters.fail_fast:
+                    break
+
+        # Phase 2: async execution for successfully loaded manifests
+        if previews:
+
+            async def _execute_all() -> None:
+                for preview in previews:
+                    if preview.manifest_path is None:
+                        continue
+                    sr = await self._execute_single(
+                        preview.actions, preview.manifest_path, parameters
+                    )
+                    sr.manifest_path = preview.manifest_path
+                    sr.metadata = preview.metadata
+                    manifest_results.append(sr)
+
+            asyncio.run(_execute_all())
+
+        return BatchSetupResults(manifest_results=manifest_results, failed_paths=failed_paths)

--- a/porringer/backend/command/sync.py
+++ b/porringer/backend/command/sync.py
@@ -607,8 +607,6 @@ class SyncCommands:
         action: SetupAction,
         environments: dict[str, Environment],
         strategy: SyncStrategy = SyncStrategy.MINIMAL,
-        *,
-        prior_results: list[SetupActionResult] | None = None,
     ) -> SetupActionResult:
         """Simulates executing an action in dry-run mode.
 
@@ -616,14 +614,13 @@ class SyncCommands:
         that the result accurately reflects whether the action would be
         skipped.
 
-        For post-sync commands (``kind is None``), the command is skipped
-        when all prior results were themselves skipped (nothing changed).
+        Post-sync commands (``kind is None``) always report success since
+        they would unconditionally run during a real execution.
 
         Args:
             action: The action to simulate.
             environments: Dict of instantiated environment plugins.
             strategy: The sync strategy (affects skip logic for packages).
-            prior_results: Results from earlier phases (used by commands).
 
         Returns:
             The simulated result.
@@ -634,15 +631,7 @@ class SyncCommands:
             case PluginKind.PROJECT | PluginKind.SCM:
                 return SetupActionResult(action=action, success=True)
             case None:
-                # Post-sync command
-                if prior_results and all(r.skipped for r in prior_results):
-                    return SetupActionResult(
-                        action=action,
-                        success=True,
-                        skipped=True,
-                        skip_reason=SkipReason.NOTHING_CHANGED,
-                        message='All prerequisites already satisfied',
-                    )
+                # Post-sync commands always "would run" in dry-run mode.
                 return SetupActionResult(action=action, success=True)
             case _:
                 return SetupActionResult(action=action, success=False, message=f'Unknown action kind: {action.kind}')
@@ -1093,8 +1082,6 @@ class SyncCommands:
         self,
         command_actions: list[SetupAction],
         context: _ExecutionPhaseContext,
-        *,
-        prior_results: list[SetupActionResult] | None = None,
     ) -> list[SetupActionResult]:
         """Execute RUN_COMMAND actions sequentially."""
         results: list[SetupActionResult] = []
@@ -1104,7 +1091,6 @@ class SyncCommands:
                     action,
                     context.environments,
                     context.parameters.strategy,
-                    prior_results=prior_results,
                 )
             else:
                 result = self._execute_run_command(action, context.working_dir, context.parameters.timeout)
@@ -1307,7 +1293,7 @@ class SyncCommands:
                 working_dir=working_dir,
                 event_queue=event_queue,
             )
-            results.extend(await self._execute_command_actions(phases[None], context, prior_results=results))
+            results.extend(await self._execute_command_actions(phases[None], context))
 
         return SetupResults(actions=actions, results=results)
 
@@ -1737,9 +1723,7 @@ class SyncCommands:
                 for preview in previews:
                     if preview.manifest_path is None:
                         continue
-                    sr = await self._execute_single(
-                        preview.actions, preview.manifest_path, parameters
-                    )
+                    sr = await self._execute_single(preview.actions, preview.manifest_path, parameters)
                     sr.manifest_path = preview.manifest_path
                     sr.metadata = preview.metadata
                     manifest_results.append(sr)

--- a/porringer/console/command/sync.py
+++ b/porringer/console/command/sync.py
@@ -22,7 +22,6 @@ from porringer.schema import (
     SubActionProgress,
     SyncStrategy,
 )
-from porringer.utility.exception import ManifestError
 
 app = typer.Typer()
 
@@ -65,6 +64,9 @@ class _ProgressState:
     completed: int = 0
     active_tasks: dict[str, TaskID] = field(default_factory=dict)
     collected_results: list[SetupActionResult] = field(default_factory=list)
+    manifests: list[SetupResults] = field(default_factory=list)
+    failed_paths: list[tuple[Path, str]] = field(default_factory=list)
+    overall_task: TaskID | None = None
 
 
 def _create_api(configuration: Configuration) -> API:
@@ -77,11 +79,6 @@ def _create_api(configuration: Configuration) -> API:
         Initialized API instance.
     """
     return API(configuration.local_configuration)
-
-
-def _count_actions(preview_results: BatchSetupResults) -> int:
-    """Count total actions in preview results."""
-    return sum(len(mr.actions) for mr in preview_results.manifest_results)
 
 
 def _progress_label(strategy: SyncStrategy) -> str:
@@ -191,15 +188,26 @@ def _handle_progress_event(
 
 async def _run_stream_with_progress(
     api: API,
-    preview_results: BatchSetupResults,
     setup_params: SetupParameters,
     progress: Progress,
-    total_actions: int,
     overall_task: TaskID | None,
     state: _ProgressState,
 ) -> None:
-    async for event in api.sync.execute_stream(preview_results, setup_params):
-        _handle_progress_event(event, progress, setup_params, total_actions, overall_task, state)
+    async for event in api.sync.execute_stream(setup_params):
+        if event.kind == ProgressEventKind.MANIFEST_LOADED and event.manifest:
+            state.manifests.append(event.manifest)
+            total = sum(len(m.actions) for m in state.manifests)
+            if overall_task is not None:
+                progress.update(overall_task, total=total)
+            elif total > 0 and not setup_params.dry_run:
+                overall_task = progress.add_task(_progress_label(setup_params.strategy), total=total)
+                state.overall_task = overall_task
+            continue
+        if event.kind == ProgressEventKind.MANIFEST_FAILED and event.failed_path:
+            state.failed_paths.append(event.failed_path)
+            continue
+        total_actions = sum(len(m.actions) for m in state.manifests)
+        _handle_progress_event(event, progress, setup_params, total_actions, state.overall_task or overall_task, state)
 
 
 def _format_cli_command(result: SetupActionResult) -> str:
@@ -364,55 +372,53 @@ def _handle_manifest(configuration: Configuration, options: ManifestOptions) -> 
             strategy=options.strategy,
         )
 
-    # Preview to get actions
+    # For dry runs, use the simple sync method (no progress bar needed).
+    # For real execution, use the streaming progress display.
     try:
-        preview_results = api.sync.preview_batch(setup_params)
-    except (ManifestError, ValueError) as e:
-        error_msg = e.error if isinstance(e, ManifestError) else str(e)
-        configuration.console.print(f'[red]Error:[/red] {error_msg}')
+        if setup_params.dry_run:
+            execute_results = api.sync.run(setup_params)
+        else:
+            execute_results = _execute_with_progress(configuration, api, setup_params)
+    except ValueError as e:
+        configuration.console.print(f'[red]Error:[/red] {e}')
         raise typer.Exit(EXIT_FAILURE) from e
 
-    # Check for failed paths (no manifest found)
-    if preview_results.failed_paths and not preview_results.manifest_results:
-        for _path, error in preview_results.failed_paths:
+    # Fast path: all manifests failed, no actions at all
+    if execute_results.failed_paths and execute_results.total_actions == 0:
+        for path, error in execute_results.failed_paths:
             configuration.console.print(f'[red]Error:[/red] {error}')
         raise typer.Exit(EXIT_FAILURE)
 
-    if preview_results.total_actions == 0 and not preview_results.failed_paths:
+    if execute_results.total_actions == 0:
         configuration.console.print('[yellow]No actions to execute[/yellow]')
         return
 
-    # Execute with async progress
-    execute_results = _execute_with_progress(configuration, api, preview_results, setup_params)
-
     _display_results(configuration, execute_results, options.dry_run, options.strategy)
 
-    if not options.dry_run and not execute_results.success:
+    if not execute_results.success:
         raise typer.Exit(EXIT_FAILURE)
 
 
 def _execute_with_progress(
     configuration: Configuration,
     api: API,
-    preview_results: BatchSetupResults,
     setup_params: SetupParameters,
 ) -> BatchSetupResults:
     """Execute installation with progress display.
 
     Uses ``execute_stream`` to receive ``ProgressEvent`` items and updates
-    a Rich progress bar accordingly.  Results are collected from the stream
-    events so no second execution is needed.
+    a Rich progress bar accordingly.  Manifests are discovered via
+    ``MANIFEST_LOADED`` events emitted by the stream — no separate preview
+    step is required.
 
     Args:
         configuration: CLI configuration with console.
         api: The API instance.
-        preview_results: Preview results with actions.
         setup_params: Setup parameters.
 
     Returns:
         BatchSetupResults from execution.
     """
-    total_actions = _count_actions(preview_results)
     state = _ProgressState()
 
     with Progress(
@@ -423,35 +429,31 @@ def _execute_with_progress(
         TextColumn('({task.completed}/{task.total})'),
         console=configuration.console,
         transient=True,
-        disable=total_actions == 0 or setup_params.dry_run,
+        disable=setup_params.dry_run,
     ) as progress:
-        overall_task = None
-        if total_actions > 0 and not setup_params.dry_run:
-            overall_task = progress.add_task(_progress_label(setup_params.strategy), total=total_actions)
-
         asyncio.run(
             _run_stream_with_progress(
                 api,
-                preview_results,
                 setup_params,
                 progress,
-                total_actions,
-                overall_task,
+                None,
                 state,
             )
         )
 
     # Build BatchSetupResults from collected events
+    # Partition results by manifest using action identity
+    manifest_action_sets = [set(id(a) for a in m.actions) for m in state.manifests]
     manifest_results: list[SetupResults] = []
-    for preview in preview_results.manifest_results:
-        sr = SetupResults(actions=preview.actions, results=list(state.collected_results))
+
+    for preview, action_ids in zip(state.manifests, manifest_action_sets, strict=False):
+        mr_results = [r for r in state.collected_results if id(r.action) in action_ids]
+        sr = SetupResults(actions=preview.actions, results=mr_results)
         sr.manifest_path = preview.manifest_path
+        sr.metadata = preview.metadata
         manifest_results.append(sr)
 
-    return BatchSetupResults(
-        manifest_results=manifest_results,
-        failed_paths=list(preview_results.failed_paths),
-    )
+    return BatchSetupResults(manifest_results=manifest_results, failed_paths=state.failed_paths)
 
 
 @app.callback(invoke_without_command=True)

--- a/porringer/console/command/sync.py
+++ b/porringer/console/command/sync.py
@@ -385,7 +385,7 @@ def _handle_manifest(configuration: Configuration, options: ManifestOptions) -> 
 
     # Fast path: all manifests failed, no actions at all
     if execute_results.failed_paths and execute_results.total_actions == 0:
-        for path, error in execute_results.failed_paths:
+        for _path, error in execute_results.failed_paths:
             configuration.console.print(f'[red]Error:[/red] {error}')
         raise typer.Exit(EXIT_FAILURE)
 

--- a/porringer/console/command/sync.py
+++ b/porringer/console/command/sync.py
@@ -166,6 +166,8 @@ def _handle_progress_event(
     overall_task: TaskID | None,
     state: _ProgressState,
 ) -> None:
+    if event.action is None:
+        return
     action_desc = _action_description(event.action)
 
     if event.kind == ProgressEventKind.ACTION_STARTED:

--- a/porringer/schema.py
+++ b/porringer/schema.py
@@ -111,7 +111,6 @@ class SkipReason(Enum):
     """
 
     ALREADY_INSTALLED = auto()
-    NOTHING_CHANGED = auto()
     NO_PROJECT_DIRECTORY = auto()
 
 
@@ -217,7 +216,7 @@ class ProgressEvent:
     action: SetupAction | None = None
     result: SetupActionResult | None = None
     sub_action: SubActionProgress | None = None
-    manifest: 'SetupResults | None' = None
+    manifest: SetupResults | None = None
     failed_path: tuple[Path, str] | None = None
 
 

--- a/porringer/schema.py
+++ b/porringer/schema.py
@@ -190,6 +190,8 @@ class SubActionProgress:
 class ProgressEventKind(Enum):
     """The kind of progress event emitted during setup execution."""
 
+    MANIFEST_LOADED = auto()
+    MANIFEST_FAILED = auto()
     ACTION_STARTED = auto()
     ACTION_COMPLETED = auto()
     SUB_ACTION_PROGRESS = auto()
@@ -204,15 +206,19 @@ class ProgressEvent:
 
     Args:
         kind: What this event represents.
-        action: The setup action this event relates to.
+        action: The setup action this event relates to (``None`` for ``MANIFEST_LOADED`` / ``MANIFEST_FAILED``).
         result: Action result (set only for ``ACTION_COMPLETED``).
         sub_action: Sub-action detail (set only for ``SUB_ACTION_PROGRESS``).
+        manifest: Per-manifest preview (set only for ``MANIFEST_LOADED``).
+        failed_path: Path and error message (set only for ``MANIFEST_FAILED``).
     """
 
     kind: ProgressEventKind
-    action: SetupAction
+    action: SetupAction | None = None
     result: SetupActionResult | None = None
     sub_action: SubActionProgress | None = None
+    manifest: 'SetupResults | None' = None
+    failed_path: tuple[Path, str] | None = None
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,32 +21,39 @@ from porringer.schema import (
 )
 
 
-def execute_via_stream(api: API, preview: BatchSetupResults, params: SetupParameters) -> BatchSetupResults:
+def execute_via_stream(api: API, params: SetupParameters) -> BatchSetupResults:
     """Drain ``execute_stream`` and build ``BatchSetupResults`` from emitted events.
 
-    This is a test helper that replaces the removed ``execute_batch`` /
-    ``execute_batch_async`` convenience methods.
+    This is a test helper that calls ``execute_stream`` directly — no
+    separate preview step is needed.
     """
+    manifests: list[SetupResults] = []
     collected: list[SetupActionResult] = []
+    failed_paths: list[tuple[Path, str]] = []
 
     async def _run() -> None:
-        async for event in api.sync.execute_stream(preview, params):
-            if event.kind == ProgressEventKind.ACTION_COMPLETED and event.result:
+        async for event in api.sync.execute_stream(params):
+            if event.kind == ProgressEventKind.MANIFEST_LOADED and event.manifest:
+                manifests.append(event.manifest)
+            elif event.kind == ProgressEventKind.MANIFEST_FAILED and event.failed_path:
+                failed_paths.append(event.failed_path)
+            elif event.kind == ProgressEventKind.ACTION_COMPLETED and event.result:
                 collected.append(event.result)
 
     asyncio.run(_run())
 
     # Partition collected results by manifest based on action identity
-    manifest_action_sets = [set(id(a) for a in mr.actions) for mr in preview.manifest_results]
+    manifest_action_sets = [set(id(a) for a in m.actions) for m in manifests]
     manifest_results: list[SetupResults] = []
 
-    for mr, action_ids in zip(preview.manifest_results, manifest_action_sets, strict=False):
+    for preview, action_ids in zip(manifests, manifest_action_sets, strict=False):
         mr_results = [r for r in collected if id(r.action) in action_ids]
-        sr = SetupResults(actions=mr.actions, results=mr_results)
-        sr.manifest_path = mr.manifest_path
+        sr = SetupResults(actions=preview.actions, results=mr_results)
+        sr.manifest_path = preview.manifest_path
+        sr.metadata = preview.metadata
         manifest_results.append(sr)
 
-    return BatchSetupResults(manifest_results=manifest_results, failed_paths=list(preview.failed_paths))
+    return BatchSetupResults(manifest_results=manifest_results, failed_paths=failed_paths)
 
 
 @pytest.fixture

--- a/tests/integration/test_bootstrap_presence.py
+++ b/tests/integration/test_bootstrap_presence.py
@@ -17,7 +17,6 @@ import pytest
 from porringer.api import API
 from porringer.core.schema import PluginKind
 from porringer.schema import SetupActionResult, SetupParameters, SkipReason
-from tests.conftest import execute_via_stream
 
 # Absolute path to the bootstrap example manifest directory
 _BOOTSTRAP_DIR = Path(__file__).resolve().parents[2] / 'examples' / 'python-bootstrap'
@@ -31,8 +30,7 @@ class TestBootstrapPresence:
     def dry_run_results(test_api: API) -> list[SetupActionResult]:
         """Dry-run the bootstrap manifest and return all action results."""
         setup_params = SetupParameters(paths=_BOOTSTRAP_DIR, dry_run=True)
-        preview = test_api.sync.preview_batch(setup_params)
-        results = execute_via_stream(test_api, preview, setup_params)
+        results = test_api.sync.run(setup_params)
 
         assert len(results.manifest_results) == 1
         return results.manifest_results[0].results

--- a/tests/integration/test_example_bootstrap.py
+++ b/tests/integration/test_example_bootstrap.py
@@ -26,8 +26,8 @@ class TestBootstrapPreview:
     @staticmethod
     @pytest.fixture
     def preview() -> SetupResults:
-        """Preview the bootstrap manifest."""
-        return SyncCommands.preview_single(_BOOTSTRAP_DIR)
+        """Parse the bootstrap manifest."""
+        return SyncCommands.parse_manifest(_BOOTSTRAP_DIR)
 
     @staticmethod
     def test_manifest_loads(preview: SetupResults) -> None:

--- a/tests/integration/test_example_presence.py
+++ b/tests/integration/test_example_presence.py
@@ -12,7 +12,6 @@ import pytest
 from porringer.api import API
 from porringer.core.schema import PluginKind
 from porringer.schema import SetupParameters, SkipReason
-from tests.conftest import execute_via_stream
 
 # Absolute path to the example manifest directory
 _EXAMPLE_DIR = Path(__file__).resolve().parents[2] / 'examples' / 'python-dev'
@@ -30,8 +29,7 @@ class TestExamplePresence:
     def dry_run_results(test_api: API) -> list[tuple[str, bool, SkipReason | None]]:
         """Dry-run the example manifest and return (package, skipped, reason) tuples for pip actions."""
         setup_params = SetupParameters(paths=_EXAMPLE_DIR, dry_run=True)
-        preview = test_api.sync.preview_batch(setup_params)
-        results = execute_via_stream(test_api, preview, setup_params)
+        results = test_api.sync.run(setup_params)
 
         assert len(results.manifest_results) == 1
         mr = results.manifest_results[0]

--- a/tests/unit/test_bootstrap_cross_platform.py
+++ b/tests/unit/test_bootstrap_cross_platform.py
@@ -38,7 +38,7 @@ class TestBootstrapDeferredRuntime:
             return original_which(cmd)
 
         with patch('shutil.which', side_effect=_which_no_runtime):
-            return SyncCommands.preview_single(_BOOTSTRAP_DIR)
+            return SyncCommands.parse_manifest(_BOOTSTRAP_DIR)
 
     @staticmethod
     def test_manifest_loads(preview_no_runtime: SetupResults) -> None:

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -21,7 +21,6 @@ from porringer.schema import (
     SyncStrategy,
 )
 from porringer.utility.exception import ManifestError
-from tests.conftest import execute_via_stream
 
 # Test constants
 EXPECTED_ACTIONS_JSON_MANIFEST = 2  # 1 install + 1 command
@@ -62,7 +61,7 @@ class TestSetupManifest:
             }
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir))
+            results = test_api.sync.parse_manifest(Path(tmpdir))
 
             assert results.manifest_path == manifest_path
             # 1 install + 1 command = 2 actions
@@ -80,7 +79,7 @@ packages.python = ["requests"]
 """
             pyproject_path.write_text(pyproject_content)
 
-            results = test_api.sync.preview_single(Path(tmpdir))
+            results = test_api.sync.parse_manifest(Path(tmpdir))
 
             assert results.manifest_path == pyproject_path
             assert len(results.actions) == 1  # 1 install
@@ -89,7 +88,7 @@ packages.python = ["requests"]
     def test_missing_manifest_raises_error(test_api: API) -> None:
         """Test that missing manifest raises ManifestError"""
         with tempfile.TemporaryDirectory() as tmpdir, pytest.raises(ManifestError):
-            test_api.sync.preview_single(Path(tmpdir))
+            test_api.sync.parse_manifest(Path(tmpdir))
 
 
 class TestSetupPreview:
@@ -107,7 +106,7 @@ class TestSetupPreview:
             }
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir))
+            results = test_api.sync.parse_manifest(Path(tmpdir))
 
             # 2 packages + 1 command = 3 actions
             assert len(results.actions) == THREE_ACTIONS
@@ -134,7 +133,7 @@ class TestSetupPreview:
             }
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir))
+            results = test_api.sync.parse_manifest(Path(tmpdir))
 
             # Only 'requests' (no filter) and 'uvloop' (matching) should be included
             assert len(results.actions) == TWO_ACTIONS
@@ -154,7 +153,7 @@ class TestSetupPreview:
             }
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir))
+            results = test_api.sync.parse_manifest(Path(tmpdir))
 
             assert len(results.actions) == THREE_ACTIONS
 
@@ -171,7 +170,7 @@ class TestSetupBatch:
             manifest_path.write_text(json.dumps(manifest_data))
 
             params = SetupParameters(paths=Path(tmpdir))
-            results = test_api.sync.preview_batch(params)
+            results = test_api.sync.run(params)
 
             assert len(results.manifest_results) == 1
             assert results.total_actions == 1
@@ -193,7 +192,7 @@ class TestSetupBatch:
             )
 
             params = SetupParameters(paths=[project1, project2])
-            results = test_api.sync.preview_batch(params)
+            results = test_api.sync.run(params)
 
             assert len(results.manifest_results) == DUAL_MANIFESTS
             assert results.total_actions == THREE_ACTIONS  # 1 + 2
@@ -212,11 +211,10 @@ class TestSetupBatch:
             (project1 / 'porringer.json').write_text(json.dumps({'version': '1', 'packages': {'python': ['requests']}}))
 
             params = SetupParameters(paths=[project1, project2], fail_fast=False)
-            results = test_api.sync.preview_batch(params)
+            results = test_api.sync.run(params)
 
             assert len(results.manifest_results) == SINGLE_MANIFEST
             assert len(results.failed_paths) == SINGLE_FAILED_PATH
-            assert results.failed_paths[FIRST_ACTION_INDEX][0] == project2
 
     @staticmethod
     def test_preview_batch_from_cache(test_api: API, temp_cache_dir) -> None:
@@ -232,7 +230,7 @@ class TestSetupBatch:
 
         # Preview from cache (paths=None)
         params = SetupParameters(paths=None)
-        results = test_api.sync.preview_batch(params)
+        results = test_api.sync.run(params)
 
         assert len(results.manifest_results) == SINGLE_MANIFEST
         assert results.total_actions == SINGLE_MANIFEST
@@ -255,7 +253,7 @@ class TestSetupBatch:
 
         # Preview from all cached
         params = SetupParameters(paths=None)
-        results = test_api.sync.preview_batch(params)
+        results = test_api.sync.run(params)
 
         assert len(results.manifest_results) == DUAL_MANIFESTS
         assert results.total_actions == TWO_ACTIONS
@@ -370,7 +368,7 @@ class TestManifestMetadata:
             }
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir))
+            results = test_api.sync.parse_manifest(Path(tmpdir))
 
             assert results.metadata is not None
             assert results.metadata.name == 'Dev Environment'
@@ -386,7 +384,7 @@ class TestManifestMetadata:
             manifest_data = {'version': '1', 'packages': {'python': ['requests']}}
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir))
+            results = test_api.sync.parse_manifest(Path(tmpdir))
 
             assert results.metadata is not None
             assert results.metadata.name is None
@@ -410,7 +408,7 @@ class TestManifestMetadata:
             }
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir))
+            results = test_api.sync.parse_manifest(Path(tmpdir))
 
             assert len(results.actions) == TWO_ACTIONS
             assert str(results.actions[0].package) == 'ruff'
@@ -432,8 +430,7 @@ class TestSetupCLI:
 
             # Test dry-run via API
             setup_params = SetupParameters(paths=Path(tmpdir), dry_run=True)
-            preview = test_api.sync.preview_batch(setup_params)
-            results = execute_via_stream(test_api, preview, setup_params)
+            results = test_api.sync.run(setup_params)
 
             # Should have 1 action for pip install
             assert len(results.manifest_results) == 1
@@ -678,8 +675,7 @@ class TestDryRunStateAware:
             manifest_path.write_text(json.dumps(manifest_data))
 
             setup_params = SetupParameters(paths=Path(tmpdir), dry_run=True)
-            preview = test_api.sync.preview_batch(setup_params)
-            results = execute_via_stream(test_api, preview, setup_params)
+            results = test_api.sync.run(setup_params)
 
             assert len(results.manifest_results) == 1
             action_result = results.manifest_results[0].results[0]
@@ -699,8 +695,7 @@ class TestDryRunStateAware:
             manifest_path.write_text(json.dumps(manifest_data))
 
             setup_params = SetupParameters(paths=Path(tmpdir), dry_run=True)
-            preview = test_api.sync.preview_batch(setup_params)
-            results = execute_via_stream(test_api, preview, setup_params)
+            results = test_api.sync.run(setup_params)
 
             assert len(results.manifest_results) == 1
             action_result = results.manifest_results[0].results[0]
@@ -718,8 +713,7 @@ class TestDryRunStateAware:
             manifest_path.write_text(json.dumps(manifest_data))
 
             setup_params = SetupParameters(paths=Path(tmpdir), dry_run=True)
-            preview = test_api.sync.preview_batch(setup_params)
-            results = execute_via_stream(test_api, preview, setup_params)
+            results = test_api.sync.run(setup_params)
 
             assert len(results.manifest_results) == 1
             action_result = results.manifest_results[0].results[0]
@@ -739,8 +733,7 @@ class TestDryRunStateAware:
             manifest_path.write_text(json.dumps(manifest_data))
 
             setup_params = SetupParameters(paths=Path(tmpdir), dry_run=True)
-            preview = test_api.sync.preview_batch(setup_params)
-            results = execute_via_stream(test_api, preview, setup_params)
+            results = test_api.sync.run(setup_params)
 
             assert len(results.manifest_results) == 1
             action_result = results.manifest_results[0].results[0]
@@ -763,7 +756,7 @@ class TestSyncStrategyUpgrade:
             }
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir), strategy=SyncStrategy.LATEST)
+            results = test_api.sync.parse_manifest(Path(tmpdir), strategy=SyncStrategy.LATEST)
 
             # 2 packages + 1 command = 3 actions
             assert len(results.actions) == THREE_ACTIONS
@@ -781,7 +774,7 @@ class TestSyncStrategyUpgrade:
             manifest_data = {'version': '1', 'packages': {'python': ['requests']}}
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir), strategy=SyncStrategy.EXACT)
+            results = test_api.sync.parse_manifest(Path(tmpdir), strategy=SyncStrategy.EXACT)
 
             assert len(results.actions) == 1
             assert results.actions[0].kind == PluginKind.PACKAGE
@@ -795,7 +788,7 @@ class TestSyncStrategyUpgrade:
             manifest_path.write_text(json.dumps(manifest_data))
 
             params = SetupParameters(paths=Path(tmpdir), strategy=SyncStrategy.LATEST)
-            results = test_api.sync.preview_batch(params)
+            results = test_api.sync.run(params)
 
             assert len(results.manifest_results) == 1
             assert results.manifest_results[0].actions[0].kind == PluginKind.PACKAGE
@@ -808,7 +801,7 @@ class TestSyncStrategyUpgrade:
             manifest_data = {'version': '1', 'packages': {'python': ['requests']}}
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir))
+            results = test_api.sync.parse_manifest(Path(tmpdir))
 
             assert results.actions[0].kind == PluginKind.PACKAGE
 
@@ -820,7 +813,7 @@ class TestSyncStrategyUpgrade:
             manifest_data = {'version': '1', 'packages': {'python': ['requests']}}
             manifest_path.write_text(json.dumps(manifest_data))
 
-            results = test_api.sync.preview_single(Path(tmpdir), strategy=SyncStrategy.LATEST)
+            results = test_api.sync.parse_manifest(Path(tmpdir), strategy=SyncStrategy.LATEST)
 
             assert 'Upgrade' in results.actions[0].description
 
@@ -834,8 +827,7 @@ class TestSyncStrategyUpgrade:
             manifest_path.write_text(json.dumps(manifest_data))
 
             setup_params = SetupParameters(paths=Path(tmpdir), dry_run=True, strategy=SyncStrategy.LATEST)
-            preview = test_api.sync.preview_batch(setup_params)
-            results = execute_via_stream(test_api, preview, setup_params)
+            results = test_api.sync.run(setup_params)
 
             assert len(results.manifest_results) == 1
             action_result = results.manifest_results[0].results[0]
@@ -852,8 +844,7 @@ class TestSyncStrategyUpgrade:
             manifest_path.write_text(json.dumps(manifest_data))
 
             setup_params = SetupParameters(paths=Path(tmpdir), dry_run=True, strategy=SyncStrategy.LATEST)
-            preview = test_api.sync.preview_batch(setup_params)
-            results = execute_via_stream(test_api, preview, setup_params)
+            results = test_api.sync.run(setup_params)
 
             assert len(results.manifest_results) == 1
             action_result = results.manifest_results[0].results[0]

--- a/tests/unit/test_project_directory.py
+++ b/tests/unit/test_project_directory.py
@@ -14,7 +14,6 @@ from porringer.schema import (
     SetupResults,
     SkipReason,
 )
-from tests.conftest import execute_via_stream
 
 
 class TestProjectDirectorySkip:
@@ -37,12 +36,10 @@ class TestProjectDirectorySkip:
             manifest_path.write_text(json.dumps(manifest_data))
 
             params = SetupParameters(paths=Path(tmpdir), project_directory=False, dry_run=True)
-            preview = test_api.sync.preview_batch(params)
+            results = test_api.sync.run(params)
 
-            # Preview should still show all actions (2: 1 package + 1 command)
-            assert preview.total_actions == 2
-
-            results = execute_via_stream(test_api, preview, params)
+            # Should show all actions (2: 1 package + 1 command)
+            assert results.total_actions == 2
 
             # The RUN_COMMAND should NOT be skipped — post_sync is decoupled
             command_skips = [r for r in results.skips if r.action.kind is None]
@@ -66,8 +63,7 @@ class TestProjectDirectorySkip:
             manifest_path.write_text(json.dumps(manifest_data))
 
             params = SetupParameters(paths=Path(tmpdir), project_directory=False, dry_run=True)
-            preview = test_api.sync.preview_batch(params)
-            results = execute_via_stream(test_api, preview, params)
+            results = test_api.sync.run(params)
 
             # Package action should not be skipped due to project_directory
             package_results = [
@@ -94,8 +90,7 @@ class TestProjectDirectorySkip:
             params = SetupParameters(paths=Path(tmpdir), dry_run=True)
             assert params.project_directory is None
 
-            preview = test_api.sync.preview_batch(params)
-            results = execute_via_stream(test_api, preview, params)
+            results = test_api.sync.run(params)
 
             # The RUN_COMMAND should NOT be in skips
             command_skips = [r for r in results.skips if r.action.kind is None]

--- a/tests/unit/test_sub_action_progress.py
+++ b/tests/unit/test_sub_action_progress.py
@@ -1,6 +1,8 @@
 """Tests for progress event stream and sub-action progress."""
 
 import asyncio
+import json
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -260,9 +262,6 @@ class TestExecuteStream:
     @staticmethod
     def test_stream_yields_events() -> None:
         """execute_stream yields ProgressEvent items via the queue-based bridge."""
-        import json
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / 'porringer.json'
             manifest_data = {'version': '1', 'packages': {'python': ['requests']}}
@@ -290,9 +289,6 @@ class TestExecuteStream:
     @staticmethod
     def test_stream_cancellation() -> None:
         """Breaking from the stream cancels the background task."""
-        import json
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / 'porringer.json'
             manifest_data = {'version': '1', 'packages': {'python': ['requests', 'flask', 'pytest', 'ruff', 'black']}}

--- a/tests/unit/test_sub_action_progress.py
+++ b/tests/unit/test_sub_action_progress.py
@@ -11,13 +11,11 @@ from porringer.core.plugin_schema.environment import PackageParameters
 from porringer.core.schema import PackageRef, PluginKind
 from porringer.plugin.pip.plugin import PipEnvironment
 from porringer.schema import (
-    BatchSetupResults,
     ProgressEvent,
     ProgressEventKind,
     SetupAction,
     SetupActionResult,
     SetupParameters,
-    SetupResults,
     SubActionProgress,
 )
 
@@ -262,51 +260,54 @@ class TestExecuteStream:
     @staticmethod
     def test_stream_yields_events() -> None:
         """execute_stream yields ProgressEvent items via the queue-based bridge."""
-        action = _make_action('test-pkg')
-        setup_results = SetupResults(
-            actions=[action],
-            results=[],
-        )
-        setup_results.manifest_path = None  # Will be set below
+        import json
+        import tempfile
 
-        preview = SetupResults(actions=[action], results=[])
-        preview.manifest_path = Path('.')
-        previews = BatchSetupResults(manifest_results=[preview], failed_paths=[])
-        params = SetupParameters(dry_run=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / 'porringer.json'
+            manifest_data = {'version': '1', 'packages': {'python': ['requests']}}
+            manifest_path.write_text(json.dumps(manifest_data))
 
-        commands = SyncCommands()
+            params = SetupParameters(paths=Path(tmpdir), dry_run=True)
+            commands = SyncCommands()
 
-        async def run() -> list[ProgressEvent]:
-            collected: list[ProgressEvent] = []
-            async for event in commands.execute_stream(previews, params):
-                collected.append(event)
-            return collected
+            async def run() -> list[ProgressEvent]:
+                collected: list[ProgressEvent] = []
+                async for event in commands.execute_stream(params):
+                    collected.append(event)
+                return collected
 
-        events = asyncio.run(run())
+            events = asyncio.run(run())
 
-        # Dry-run install actions should produce start+complete event pairs
-        started = [e for e in events if e.kind == ProgressEventKind.ACTION_STARTED]
-        completed = [e for e in events if e.kind == ProgressEventKind.ACTION_COMPLETED]
-        assert len(started) == len(completed)
+            # Should have at least a MANIFEST_LOADED event + start/complete pairs
+            manifest_events = [e for e in events if e.kind == ProgressEventKind.MANIFEST_LOADED]
+            assert len(manifest_events) >= 1
+
+            started = [e for e in events if e.kind == ProgressEventKind.ACTION_STARTED]
+            completed = [e for e in events if e.kind == ProgressEventKind.ACTION_COMPLETED]
+            assert len(started) == len(completed)
 
     @staticmethod
     def test_stream_cancellation() -> None:
         """Breaking from the stream cancels the background task."""
-        actions = [_make_action(f'pkg-{i}') for i in range(5)]
-        preview = SetupResults(actions=actions, results=[])
-        preview.manifest_path = Path('.')
-        previews = BatchSetupResults(manifest_results=[preview], failed_paths=[])
-        params = SetupParameters(dry_run=True)
+        import json
+        import tempfile
 
-        commands = SyncCommands()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / 'porringer.json'
+            manifest_data = {'version': '1', 'packages': {'python': ['requests', 'flask', 'pytest', 'ruff', 'black']}}
+            manifest_path.write_text(json.dumps(manifest_data))
 
-        async def run() -> list[ProgressEvent]:
-            collected: list[ProgressEvent] = []
-            async for event in commands.execute_stream(previews, params):
-                collected.append(event)
-                if len(collected) >= MIN_STREAM_EVENTS:
-                    break  # early exit
-            return collected
+            params = SetupParameters(paths=Path(tmpdir), dry_run=True)
+            commands = SyncCommands()
 
-        events = asyncio.run(run())
-        assert len(events) >= MIN_STREAM_EVENTS
+            async def run() -> list[ProgressEvent]:
+                collected: list[ProgressEvent] = []
+                async for event in commands.execute_stream(params):
+                    collected.append(event)
+                    if len(collected) >= MIN_STREAM_EVENTS:
+                        break  # early exit
+                return collected
+
+            events = asyncio.run(run())
+            assert len(events) >= MIN_STREAM_EVENTS


### PR DESCRIPTION
Replace the two-step preview-then-execute pattern with single entry points:
- Rename preview_single to parse_manifest (low-level utility only)
- Remove preview_batch entirely
- execute_stream now resolves paths, parses manifests, and executes in one call
- Add run() as a synchronous convenience method
- Add MANIFEST_LOADED/MANIFEST_FAILED progress event kinds
- Make ProgressEvent.action optional for manifest-level events
- Update CLI, tests, and docs to use the new API

Closes #30