### PR TITLE
Remove global include_prereleases from SetupParameters

### DIFF
--- a/porringer/backend/command/core/presence.py
+++ b/porringer/backend/command/core/presence.py
@@ -52,9 +52,9 @@ def dry_run_action(
         project_environments: Optional dict of project-environment
             plugins, used to look up ``PluginManager`` instances for
             plugin-target presence checks.
-        parameters: Full setup parameters.  When provided, ``strategy``,
-            ``detect_updates`` and ``include_prereleases`` are read
-            from it.  When ``None``, ``SyncStrategy.MINIMAL`` is used.
+        parameters: Full setup parameters.  When provided, ``strategy``
+            and ``detect_updates`` are read from it.  When ``None``,
+            ``SyncStrategy.MINIMAL`` is used.
 
     Returns:
         The simulated result.
@@ -127,12 +127,11 @@ def _dry_run_package_action(
             msg: str | None = installed_detail
 
             if parameters is not None and parameters.detect_updates:
-                use_prereleases = action.include_prereleases or parameters.include_prereleases
                 newer = _check_for_newer_version(
                     env,
                     action.package,
                     installed_ver,
-                    include_prereleases=use_prereleases,
+                    include_prereleases=action.include_prereleases,
                 )
                 if newer is not None:
                     skip_reason = SkipReason.UPDATE_AVAILABLE
@@ -206,12 +205,11 @@ def _dry_run_plugin_action(
 
         if detect and has_env and action.installer is not None and parameters is not None:
             env = environments[action.installer]
-            use_prereleases = action.include_prereleases or parameters.include_prereleases
             newer = _check_for_newer_version(
                 env,
                 action.package,
                 installed_ver,
-                include_prereleases=use_prereleases,
+                include_prereleases=action.include_prereleases,
             )
             if newer is not None:
                 skip_reason = SkipReason.UPDATE_AVAILABLE

--- a/porringer/schema/execution.py
+++ b/porringer/schema/execution.py
@@ -139,10 +139,6 @@ class SetupParameters(BaseModel):
             'Adds network latency; the GUI sets this explicitly.'
         ),
     )
-    include_prereleases: bool = Field(
-        default=False,
-        description='Include pre-release versions when checking for updates',
-    )
     plugins: list[str] | None = Field(
         default=None,
         description=(

--- a/tests/unit/test_update_detection.py
+++ b/tests/unit/test_update_detection.py
@@ -1,8 +1,8 @@
 """Tests for update detection during dry-run.
 
 Covers the new ``SkipReason.UPDATE_AVAILABLE`` path, version fields
-on ``SetupActionResult``, and the ``detect_updates`` /
-``include_prereleases`` flags on ``SetupParameters``.
+on ``SetupActionResult``, and the ``detect_updates`` flag on
+``SetupParameters``.
 """
 
 from __future__ import annotations
@@ -221,25 +221,8 @@ class TestDryRunUpdateAvailable:
         assert result.skip_reason == SkipReason.ALREADY_INSTALLED
 
     @staticmethod
-    def test_include_prereleases_forwarded() -> None:
-        """include_prereleases flag is threaded to the check_updates call."""
-        action = _make_action()
-        env = _make_env(
-            installed=[Package(name='ruff', version='0.8.0')],
-            updates=[],
-        )
-        envs = {'pip': env}
-        params = SetupParameters(dry_run=True, detect_updates=True, include_prereleases=True)
-
-        _dry_run_package_action(action, envs, parameters=params)
-
-        call_args = env.check_updates.call_args
-        check_params: CheckUpdatesParameters = call_args[0][0]
-        assert check_params.include_prereleases is True
-
-    @staticmethod
-    def test_per_package_prereleases_overrides_global() -> None:
-        """Per-action include_prereleases=True is combined with global flag."""
+    def test_per_action_prereleases_forwarded() -> None:
+        """Per-action include_prereleases is threaded to check_updates."""
         action = _make_action()
         action.include_prereleases = True
         env = _make_env(
@@ -247,8 +230,7 @@ class TestDryRunUpdateAvailable:
             updates=[Package(name='ruff', version='0.9.0a1')],
         )
         envs = {'pip': env}
-        # Global is False, but per-package is True → prereleases included
-        params = SetupParameters(dry_run=True, detect_updates=True, include_prereleases=False)
+        params = SetupParameters(dry_run=True, detect_updates=True)
 
         _dry_run_package_action(action, envs, parameters=params)
 
@@ -301,13 +283,11 @@ class TestSetupParametersDefaults:
     def test_defaults() -> None:
         params = SetupParameters()
         assert params.detect_updates is False
-        assert params.include_prereleases is False
 
     @staticmethod
     def test_explicit_values() -> None:
-        params = SetupParameters(detect_updates=True, include_prereleases=True)
+        params = SetupParameters(detect_updates=True)
         assert params.detect_updates is True
-        assert params.include_prereleases is True
 
 
 # ---------------------------------------------------------------------------
@@ -450,7 +430,7 @@ class TestPluginTargetUpdateDetection:
         manager.tool_name.return_value = 'pdm'
         manager.is_available.return_value = True
 
-        params = SetupParameters(dry_run=True, detect_updates=True, include_prereleases=False)
+        params = SetupParameters(dry_run=True, detect_updates=True)
 
         with patch(
             'porringer.backend.command.core.presence.find_plugin_manager',
@@ -458,7 +438,7 @@ class TestPluginTargetUpdateDetection:
         ):
             result = dry_run_action(action, envs, parameters=params)
 
-        # Per-package flag overrides global False
+        # Per-action flag is threaded through
         call_args = env.check_updates.call_args
         check_params: CheckUpdatesParameters = call_args[0][0]
         assert check_params.include_prereleases is True


### PR DESCRIPTION
Per-action SetupAction.include_prereleases (sourced from PackageSpec) is now the single source of truth. The global toggle on SetupParameters was redundant and could silently override per-package intent.

Closes #47